### PR TITLE
fix(sdk): move packages that only pull in types to dev dependencies

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -9,19 +9,19 @@
       "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
-        "@cityofzion/neo3-invoker": "^1.0.3",
-        "@cityofzion/neo3-parser": "^1.4.0",
-        "@types/lodash": "^4.14.176",
-        "@types/node": "^16.11.11",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
+        "@cityofzion/neo3-invoker": "^1.0.3",
+        "@cityofzion/neo3-parser": "^1.4.0",
         "@cityofzion/neon-core": "^5.0.0-next.16",
         "@cityofzion/neon-invoker": "^1.0.2",
         "@cityofzion/neon-parser": "^1.5.0",
         "@types/chai": "^4.3.3",
         "@types/expect": "^24.3.0",
+        "@types/lodash": "^4.14.176",
         "@types/mocha": "^9.1.1",
+        "@types/node": "^16.11.11",
         "assert": "^2.0.0",
         "chai": "^4.3.6",
         "cross-env": "^7.0.3",
@@ -146,6 +146,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cityofzion/neo3-invoker/-/neo3-invoker-1.0.4.tgz",
       "integrity": "sha512-N+peDiJSHcRdm6jPrIRdC/NO/k2jazwdcTH+RAEeeckmpxx9+fCNQE5zdfFfvCvinHnJ43eHyTHoymkt4mK2aQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cityofzion/neon-core": "^5.2.0"
@@ -154,7 +155,8 @@
     "node_modules/@cityofzion/neo3-parser": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@cityofzion/neo3-parser/-/neo3-parser-1.5.2.tgz",
-      "integrity": "sha512-VVWBNeJIXFVdFEgzchZmX09UGJazNUM/caq+mwyzEy2vsZ60JKjWiCzNo9yjViSe4YaWoE8RwUEcuZkMw8Ku0A=="
+      "integrity": "sha512-VVWBNeJIXFVdFEgzchZmX09UGJazNUM/caq+mwyzEy2vsZ60JKjWiCzNo9yjViSe4YaWoE8RwUEcuZkMw8Ku0A==",
+      "dev": true
     },
     "node_modules/@cityofzion/neon-api": {
       "version": "5.2.0",
@@ -170,6 +172,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@cityofzion/neon-core/-/neon-core-5.2.0.tgz",
       "integrity": "sha512-wGlZJduEXt4Ar1VuP0+x/RzNvkG83isfHk+yF2+uS+BjJ6LwZzm1Z0hnIaj54+YqeygWHktHouCHNnnbghdx7w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "3.0.0",
@@ -404,6 +407,7 @@
       "version": "4.14.186",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
       "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mocha": {
@@ -417,6 +421,7 @@
       "version": "16.11.62",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.62.tgz",
       "integrity": "sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -461,6 +466,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -685,12 +691,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -728,6 +736,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/boxen": {
@@ -854,6 +863,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/browser-stdout": {
@@ -867,6 +877,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
@@ -876,6 +887,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1256,6 +1268,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "node-fetch": "2.6.7"
@@ -1280,6 +1293,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
       "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/crypto-random-string": {
@@ -1439,6 +1453,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -1454,6 +1469,7 @@
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -1571,6 +1587,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2030,6 +2047,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -2050,6 +2068,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hash.js": "^1.0.3",
@@ -2085,6 +2104,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2136,6 +2156,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -2900,6 +2921,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
       "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -2913,6 +2935,7 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -3050,12 +3073,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/minimatch": {
@@ -3226,6 +3251,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -3878,6 +3904,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -4310,6 +4337,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-mocha": {
@@ -4873,12 +4901,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -5259,6 +5289,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cityofzion/neo3-invoker/-/neo3-invoker-1.0.4.tgz",
       "integrity": "sha512-N+peDiJSHcRdm6jPrIRdC/NO/k2jazwdcTH+RAEeeckmpxx9+fCNQE5zdfFfvCvinHnJ43eHyTHoymkt4mK2aQ==",
+      "dev": true,
       "requires": {
         "@cityofzion/neon-core": "^5.2.0"
       }
@@ -5266,7 +5297,8 @@
     "@cityofzion/neo3-parser": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@cityofzion/neo3-parser/-/neo3-parser-1.5.2.tgz",
-      "integrity": "sha512-VVWBNeJIXFVdFEgzchZmX09UGJazNUM/caq+mwyzEy2vsZ60JKjWiCzNo9yjViSe4YaWoE8RwUEcuZkMw8Ku0A=="
+      "integrity": "sha512-VVWBNeJIXFVdFEgzchZmX09UGJazNUM/caq+mwyzEy2vsZ60JKjWiCzNo9yjViSe4YaWoE8RwUEcuZkMw8Ku0A==",
+      "dev": true
     },
     "@cityofzion/neon-api": {
       "version": "5.2.0",
@@ -5279,6 +5311,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@cityofzion/neon-core/-/neon-core-5.2.0.tgz",
       "integrity": "sha512-wGlZJduEXt4Ar1VuP0+x/RzNvkG83isfHk+yF2+uS+BjJ6LwZzm1Z0hnIaj54+YqeygWHktHouCHNnnbghdx7w==",
+      "dev": true,
       "requires": {
         "abort-controller": "3.0.0",
         "bn.js": "5.2.0",
@@ -5474,7 +5507,8 @@
     "@types/lodash": {
       "version": "4.14.186",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==",
+      "dev": true
     },
     "@types/mocha": {
       "version": "9.1.1",
@@ -5485,7 +5519,8 @@
     "@types/node": {
       "version": "16.11.62",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.62.tgz",
-      "integrity": "sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ=="
+      "integrity": "sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -5524,6 +5559,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -5679,12 +5715,14 @@
     "base-x": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -5701,7 +5739,8 @@
     "bn.js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+      "dev": true
     },
     "boxen": {
       "version": "1.3.0",
@@ -5797,7 +5836,8 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -5809,6 +5849,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "dev": true,
       "requires": {
         "base-x": "^4.0.0"
       }
@@ -5817,6 +5858,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -6075,6 +6117,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
       "requires": {
         "node-fetch": "2.6.7"
       }
@@ -6093,7 +6136,8 @@
     "crypto-js": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+      "dev": true
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -6199,6 +6243,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -6212,7 +6257,8 @@
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
         }
       }
     },
@@ -6301,7 +6347,8 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
     },
     "execa": {
       "version": "0.7.0",
@@ -6621,6 +6668,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -6636,6 +6684,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -6667,7 +6716,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -6694,7 +6744,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -7207,12 +7258,14 @@
     "loglevel": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+      "dev": true
     },
     "loglevel-plugin-prefix": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
-      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g=="
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -7312,12 +7365,14 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -7441,6 +7496,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -7885,7 +7941,8 @@
     "scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
     },
     "semver": {
       "version": "5.7.1",
@@ -8196,7 +8253,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "ts-mocha": {
       "version": "10.0.0",
@@ -8604,12 +8662,14 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -22,19 +22,19 @@
   "author": "COZ, Inc.",
   "license": "ISC",
   "dependencies": {
-    "@cityofzion/neo3-invoker": "^1.0.3",
-    "@cityofzion/neo3-parser": "^1.4.0",
-    "@types/lodash": "^4.14.176",
-    "@types/node": "^16.11.11",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/chai": "^4.3.3",
     "@types/expect": "^24.3.0",
     "@types/mocha": "^9.1.1",
+    "@types/lodash": "^4.14.176",
+    "@types/node": "^16.11.11",
     "@cityofzion/neon-core": "^5.0.0-next.16",
     "@cityofzion/neon-invoker": "^1.0.2",
     "@cityofzion/neon-parser": "^1.5.0",
+    "@cityofzion/neo3-invoker": "^1.0.3",
+    "@cityofzion/neo3-parser": "^1.4.0",
     "assert": "^2.0.0",
     "chai": "^4.3.6",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
The current packages do not need to be dependencies:

```
"@cityofzion/neo3-invoker": "^1.0.3",
"@cityofzion/neo3-parser": "^1.4.0",
"@types/lodash": "^4.14.176",
"@types/node": "^16.11.11",
```

`@types/*` can be moved to dev dep. 

`@cityofzion/neo3-invoker` and `@cityofzion/neo3-parser` only pull in types so it can also be a dev dep 